### PR TITLE
Fltk as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/fltk"]
+	path = thirdparty/fltk
+	url = https://github.com/fltk/fltk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(minesweeper)
+
+option(BUILD_FLTK_TEST "build FLTK hello_world" ON)
+
+set(FLTK_BUILD_TESTS OFF)
+set(FLTK_BUILD_FLUID OFF)
+set(FLTK_BUILD_SHARED_LIBS ON)
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  set(BUILD_FLTK_TEST ON)
+endif()
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+if(NOT TARGET fltk)
+  add_subdirectory(thirdparty/fltk)
+endif()
+
+if(BUILD_FLTK_TEST)
+  add_executable(fltk_hello_world test/fltk_hello_world.cpp)
+  target_link_libraries(fltk_hello_world PUBLIC fltk)
+  target_include_directories(fltk_hello_world PUBLIC)
+endif()

--- a/test/fltk_hello_world.cpp
+++ b/test/fltk_hello_world.cpp
@@ -1,0 +1,31 @@
+//
+// Hello, World! program for the Fast Light Tool Kit (FLTK).
+//
+// Copyright 1998-2021 by Bill Spitzak and others.
+//
+// This library is free software. Distribution and use rights are outlined in
+// the file "COPYING" which should have been included with this file.  If this
+// file is missing or damaged, see the license at:
+//
+//     https://www.fltk.org/COPYING.php
+//
+// Please see the following page on how to report bugs and issues:
+//
+//     https://www.fltk.org/bugs.php
+//
+
+#include <FL/Fl.H>
+#include <FL/Fl_Box.H>
+#include <FL/Fl_Window.H>
+
+int main(int argc, char **argv) {
+    Fl_Window *window = new Fl_Window(340, 180);
+    Fl_Box *box = new Fl_Box(20, 40, 300, 100, "Hello, World!");
+    box->box(FL_UP_BOX);
+    box->labelfont(FL_BOLD + FL_ITALIC);
+    box->labelsize(36);
+    box->labeltype(FL_SHADOW_LABEL);
+    window->end();
+    window->show(argc, argv);
+    return Fl::run();
+}


### PR DESCRIPTION
### Added FLTK library as a git submodule.
Reasons:
1. Unified CMakeLists
2. Easy install and work on Windows
3. The support for external lib will be added in the future.

This build works on linux. Windows needs testing. Fixes will be applied at `main`.